### PR TITLE
Fix: use relative file paths

### DIFF
--- a/metar.go
+++ b/metar.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/esperlu/metar/data"
+	"./data"
 )
 
 // Constants to fetch Weather reports from aviationweather.com

--- a/util/updateStations.go
+++ b/util/updateStations.go
@@ -28,7 +28,7 @@ type station struct {
 }
 
 const (
-	dataFile       string = "/home/jeanluc/golang/src/jeanluc/metar/data/ad_list.go"
+	dataFile       string = "../data/ad_list.go"
 	noaaURL        string = "https://www.aviationweather.gov/docs/metar/stations.txt"
 	ourairportsURL string = "https://ourairports.com/data/airports.csv"
 )


### PR DESCRIPTION
Hey,

I updated those file paths to relative file paths in order to be able to compile updateStations.go and metar.go on different machines without having to adjust the source files.

However I'm not sure if this could cause other troubles or, as I used Unix relative path names, if this also works when compiling in a Windows environment.

Best regards